### PR TITLE
Feat/edit-delete-row

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.2.6",
     "antd": "^5.10.2",
+    "dayjs": "^1.11.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   antd:
     specifier: ^5.10.2
     version: 5.10.2(react-dom@18.2.0)(react@18.2.0)
+  dayjs:
+    specifier: ^1.11.10
+    version: 1.11.10
   react:
     specifier: ^18.2.0
     version: 18.2.0

--- a/src/components/Table/ActionDropdown/index.tsx
+++ b/src/components/Table/ActionDropdown/index.tsx
@@ -1,6 +1,6 @@
 import { DownOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
-import { Button, Dropdown, message } from 'antd';
+import { Button, Dropdown } from 'antd';
 import { FC } from 'react';
 
 interface IActionDropdown {
@@ -16,14 +16,12 @@ const items: MenuProps['items'] = [
   {
     label: 'Delete',
     key: 'delete',
+    danger: true,
   }
 ];
 
 const ActionDropdown: FC<IActionDropdown> = ({ onEdit, onDelete }) => {
-  const handleMenuClick: MenuProps['onClick'] = (e) => {
-    message.info('Click on' + e.key);
-    e.key === 'edit' ? onEdit() : onDelete();
-  };
+  const handleMenuClick: MenuProps['onClick'] = (e) => e.key === 'edit' ? onEdit() : onDelete();
 
   const menuProps = {
     items,

--- a/src/components/Table/ActionDropdown/index.tsx
+++ b/src/components/Table/ActionDropdown/index.tsx
@@ -1,7 +1,7 @@
 import { DownOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Button, Dropdown } from 'antd';
-import { FC } from 'react';
+import { FC, useCallback } from 'react';
 
 interface IActionDropdown {
     onEdit: () => void;
@@ -21,7 +21,7 @@ const items: MenuProps['items'] = [
 ];
 
 const ActionDropdown: FC<IActionDropdown> = ({ onEdit, onDelete }) => {
-  const handleMenuClick: MenuProps['onClick'] = (e) => e.key === 'edit' ? onEdit() : onDelete();
+  const handleMenuClick: MenuProps['onClick'] = useCallback( (e: { key: string }) => e.key === 'edit' ? onEdit() : onDelete(),[onDelete, onEdit]);
 
   const menuProps = {
     items,

--- a/src/components/Table/EditableCell/index.tsx
+++ b/src/components/Table/EditableCell/index.tsx
@@ -1,0 +1,80 @@
+import { DatePicker, Form, Input, InputNumber, Select } from 'antd';
+import { FC, HTMLAttributes, ReactNode, useCallback } from 'react';
+
+import { ITableData } from '../mock-data.ts';
+
+const selectOptions = [
+  { value: 'expense', label: 'expense' },
+  { value: 'income', label: 'income' },
+];
+interface IEditableCell extends HTMLAttributes<HTMLElement> {
+    editing: boolean;
+    dataIndex: string;
+    title: string;
+    inputType: 'number' | 'text' | 'date' | 'select';
+    record: ITableData;
+    index: number;
+    children: ReactNode;
+}
+
+export const EditableCell: FC<IEditableCell> = ({
+  editing,
+  dataIndex,
+  title,
+  inputType,
+  children,
+  ...restProps
+}) => {
+  const generalValidationRules = useCallback( () => {
+    if (dataIndex !== 'amount') {
+      return [
+        {
+          required: true,
+          message: `Please enter ${title}`,
+        }
+      ];
+    } else {
+      return [
+        {
+          required: true,
+          pattern: new RegExp(/^[0-9]+$/),
+          message: 'Please enter a valid number (using 0-9)',
+        }  
+      ];
+    }
+  }, [dataIndex, title]);
+
+  const inputNode = () => {
+    switch (inputType) {
+      case 'number':
+        return  <InputNumber min={0} type="number"/>;
+
+      case 'date':
+        return <DatePicker key={dataIndex} format='DD/MM/YYYY' />;
+
+      case 'select':
+        return <Select
+          key={dataIndex}
+          options={selectOptions}
+        />;
+
+      default:
+        return <Input type="text"/>;
+    }
+  };
+
+  return (
+    <td {...restProps}>
+      {editing ? (
+        <Form.Item
+          name={dataIndex}
+          rules={generalValidationRules()}
+        >
+          {inputNode()}
+        </Form.Item>
+      ) : (
+        children
+      )}
+    </td>
+  );
+};

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -50,8 +50,9 @@ const Table = () => {
   }, [form, setTableData, tableData]);
   
   const handleDelete = useCallback( (key: string)=> {
-    console.log('delete', key);
-  }, []);
+    const newData = [...tableData];
+    setTableData(newData.filter((item) => item.key !== key));
+  }, [setTableData, tableData]);
 
   const columns = useMemo( () =>  [
     {

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -1,59 +1,134 @@
-import { Table as AntdTable } from 'antd';
-import type { ColumnsType } from 'antd/es/table';
-import { useCallback, useMemo } from 'react';
+import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
+import { Button, Form, Space, Table as AntdTable } from 'antd';
+import dayjs from 'dayjs';
+import { Key, useCallback, useMemo, useState } from 'react';
 
 import useLocalStorageState from '../../hooks/useLocalStorage.tsx';
 
 import ActionDropdown from './ActionDropdown';
+import { EditableCell } from './EditableCell';
 import { currency, ITableData, mockTableData } from './mock-data.ts';
 import SummaryFooter from './SummaryFooter';
-import { formatDate } from './table.helpers.ts';
 
 const Table = () => {
-  const [tableData] = useLocalStorageState('tableData', mockTableData);
+  const [form] = Form.useForm();
+  const [tableData, setTableData] = useLocalStorageState('tableData', mockTableData);
+  const [editingKey, setEditingKey] = useState('');
+
+  const cancelRowEditing = () =>
+    setEditingKey('');
+
+  const isEditing = useCallback((record: ITableData) => record.key === editingKey, [editingKey]);
+
+  const handleEdit = useCallback((record: Partial<ITableData> & { key: Key })=> {
+    form.setFieldsValue({ date: new Date(), amount: 0, type: 'income', note: '', ...record });
+    setEditingKey(record.key);
+  }, [form]);
+
+  const handleSaveEdit = useCallback( async (key: Key) => {
+    try {
+      const row = (await form.validateFields()) as ITableData;
+
+      const newData = [...tableData];
+      const index = newData.findIndex((item) => key === item.key);
+      if (index > -1) {
+        const item = newData[index];
+        newData.splice(index, 1, {
+          ...item,
+          ...row,
+        });
+        setTableData(newData);
+        setEditingKey('');
+      } else {
+        newData.push(row);
+        setTableData(newData);
+        setEditingKey('');
+      }
+    } catch (errInfo) {
+      console.log('Validate Failed:', errInfo);
+    }
+  }, [form, setTableData, tableData]);
   
-  const handleEdit = useCallback((id: string)=> {
-    console.log('edit', id);
-  }, []);
-  
-  const handleDelete = useCallback( (id: string)=> {
-    console.log('delete', id);
+  const handleDelete = useCallback( (key: string)=> {
+    console.log('delete', key);
   }, []);
 
-  const columns: ColumnsType<ITableData> = [
+  const columns = useMemo( () =>  [
     {
       title: 'Date',
       dataIndex: 'date',
-      key: 'date', 
-      render: (date) => formatDate(date),
-      sorter: (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+      key: 'date',
+      editable: true,
+      render: (date: Date) => dayjs(date).format('DD/MM/YYYY'),
+      sorter: (a: ITableData, b: ITableData) => new Date(a.date.valueOf()).getTime() - new Date(b.date.valueOf()).getTime()
     },
     {
       title: 'Amount',
       dataIndex: 'amount',
       key: 'amount',
-      render: (_, row: ITableData) => <div>{`${row.type === 'expense' ? '-' : ''}${row.amount}${currency}`}</div>,
-      sorter: (a, b) => Number(a.amount - b.amount)
+      editable: true,
+      render: (_: unknown, row: ITableData) => <div>{`${row.type === 'expense' ? '-' : ''}${row.amount}${currency}`}</div>,
+      sorter: (a: ITableData, b: ITableData) => Number(a.amount - b.amount)
     },
     {
       title: 'Type',
       dataIndex: 'type',
       key: 'type',
+      editable: true,
     },
     {
       title: 'Note',
       dataIndex: 'note',
       key: 'note',
+      editable: true,
     },
     {
       title: 'Action',
       key: 'action',
-      render: (_, { id }: ITableData) => (
-        <ActionDropdown onEdit={() => handleEdit(id)} onDelete={() => handleDelete(id)} />
-      )
+      render: (_: unknown, record: ITableData) => {
+        const editing = isEditing(record);
+        return editing ? (
+          <Space>
+            <Button onClick={() => handleSaveEdit(record.key)} type="primary" shape="circle" icon={<CheckOutlined />} />
+            <Button onClick={cancelRowEditing} type="primary" danger shape="circle" icon={<CloseOutlined />} />
+          </Space>
+        ) : (
+          <ActionDropdown onEdit={() => handleEdit(record)} onDelete={() => handleDelete(record.key)}/>
+        );
+      }
     },
-  ];
-  
+  ], [handleDelete, handleEdit, handleSaveEdit, isEditing]);
+
+  const mergedColumns = useMemo( () => columns.map((col) => {
+    if (!col.editable) {
+      return col;
+    }
+
+    const getInputType = () => {
+      switch (col.dataIndex) {
+        case 'amount':
+          return 'number';
+        case 'date':
+          return 'date';
+        case 'type':
+          return 'select';
+        default:
+          return 'text';
+      }
+    };
+
+    return {
+      ...col,
+      onCell: (record: ITableData) => ({
+        record,
+        inputType: getInputType(),
+        dataIndex: col.dataIndex,
+        title: col.title,
+        editing: isEditing(record),
+      }),
+    };
+  }),[columns, isEditing]);
+
   const totalAmount = useMemo(() => tableData.reduce((acc, { amount, type }) => {
     if (type === 'expense') {
       return acc - amount;
@@ -64,12 +139,22 @@ const Table = () => {
 
   const summary = useCallback(() => <SummaryFooter totalAmount={totalAmount}/>, [totalAmount]);
 
-  return <AntdTable 
-    rowKey="id"
-    columns={columns}
-    dataSource={tableData}
-    summary={summary}
-    pagination={{ position: ['none', 'none'] }} />;
+  return <Form form={form} component={false}>
+    <AntdTable
+      components={{
+        body: {
+          cell: EditableCell,
+        },
+      }}
+      bordered
+      rowKey="key"
+      columns={mergedColumns}
+      dataSource={tableData}
+      summary={summary}
+      pagination={{ position: ['none', 'none'] }}
+    />
+  </Form>
+  ;
 };
 
 export default Table;

--- a/src/components/Table/mock-data.ts
+++ b/src/components/Table/mock-data.ts
@@ -1,6 +1,9 @@
+import * as dayjs from 'dayjs';
+import { Dayjs } from 'dayjs';
+
 export interface ITableData {
-    id: string;
-    date: Date | string;
+    key: string;
+    date: Dayjs;
     amount: number;
     type: 'income' | 'expense';
     note: string;
@@ -8,29 +11,29 @@ export interface ITableData {
 
 export const mockTableData: ITableData[] = [
   {
-    id: '1',
-    date: new Date(2023, 9, 5),
+    key: '1',
+    date: dayjs('2023-09-25'),
     amount: 3000,
     type: 'income',
     note: 'Salary',
   },
   {
-    id: '2',
-    date: new Date(2023, 9, 14),
+    key: '2',
+    date: dayjs('2023-09-20'),
     amount: 100,
     type: 'expense',
     note: 'Gift',
   },
   {
-    id: '3',
-    date: new Date(2023, 9, 10),
+    key: '3',
+    date: dayjs('2023-10-25'),
     amount: 1000,
     type: 'expense',
     note: 'Rent',
   },
   {
-    id: '4',
-    date: new Date(2023, 9, 21),
+    key: '4',
+    date: dayjs('2023-09-26'),
     amount: 200,
     type: 'expense',
     note: 'Forest & mountain camping weekend',

--- a/src/hooks/useLocalStorage.tsx
+++ b/src/hooks/useLocalStorage.tsx
@@ -1,4 +1,15 @@
+import dayjs from 'dayjs';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+
+const dayjsReviver = (_: string, value: unknown) => {
+  if (typeof value === 'string') {
+    // Check if the string matches the ISO 8601 format
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/.test(value)) {
+      return dayjs(value); // Convert the string to a dayjs object
+    }
+  }
+  return value; // Return the original value for other properties
+};
 
 function useLocalStorageState<T>(
   key: string,
@@ -8,7 +19,7 @@ function useLocalStorageState<T>(
   const getStoredValue = (): T => {
     try {
       const item = localStorage.getItem(key);
-      return item ? JSON.parse(item) : initialValue;
+      return item ? JSON.parse(item, dayjsReviver) : initialValue;
     } catch (error) {
       console.error('Error retrieving data from local storage:', error);
       return initialValue;


### PR DESCRIPTION
Implemented edit & delete functionality according to these requirements:

1. When the user clicks the action button and selects "Delete", this data should be removed from localStorage and should not appear in the table, and the Total value should be recalculated

2. When the user clicks the action button and selects "Edit", the current row should display editable cells with the default values of the edited transaction

    1. The Date column must contain input with DatePicker
    2. The amount column must contain input type number _(+ add numeric validation to Amount field)_
    3. The Type column must contain select with 2 options
    4. The Note column should contain input type text
    5. instead of Action dropdown should show 2 icon button ‘✕’ and ‘✓’
        1. When the user presses "✕", the changes are not applied and the edit mode is exited
        2. When the user clicks "✓", the data should be updated in localStorage and displayed in the table, and the total value             should be recalculated. and also exits the editing mode
